### PR TITLE
Improve virtualenv command suggestion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ somewhat unwieldy to write.
 Set up a virtualenv:
 
 ```
-virtualenv --python /usr/bin/python2.7 ~/venv/kiplot
+virtualenv --python /usr/bin/python2.7 --system-site-packages ~/venv/kiplot 
 source ~/venv/kiplot/bin/activate
 ```
 


### PR DESCRIPTION
Without the Python in the virtualenv doesn't know about pcbnew module. This lets you avoid messing about with PYTHONPATH.