### PR TITLE
Let pcbnew check for layer names

### DIFF
--- a/src/kiplot/__main__.py
+++ b/src/kiplot/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import pcbnew
 import os
 import sys
 
@@ -38,10 +39,13 @@ def main():
                       .format(args.plot_config))
         sys.exit(EXIT_BAD_ARGS)
 
+    board = pcbnew.LoadBoard(args.board_file)
+    logging.debug("Board loaded")
+
     cr = config_reader.CfgYamlReader()
 
     with open(args.plot_config) as cf_file:
-        cfg = cr.read(cf_file)
+        cfg = cr.read(cf_file, board)
 
     # relative to CWD (absolute path overrides)
     outdir = os.path.join(os.getcwd(), args.out_dir)

--- a/src/kiplot/kiplot.py
+++ b/src/kiplot/kiplot.py
@@ -121,32 +121,23 @@ class Plotter(object):
             layer = l.layer
             suffix = l.suffix
             desc = l.desc
-
-            # for inner layers, we can now check if the layer exists
-            if layer.is_inner:
-
-                if layer.layer < 1 or layer.layer >= layer_cnt - 1:
-                    raise PlotError(
-                        "Inner layer {} is not valid for this board"
-                        .format(layer.layer))
-
             # Set current layer
-            plot_ctrl.SetLayer(layer.layer)
+            plot_ctrl.SetLayer(layer)
 
             # Skipping NPTH is controlled by whether or not this is
             # a copper layer
-            is_cu = pcbnew.IsCopperLayer(layer.layer)
+            is_cu = pcbnew.IsCopperLayer(layer)
             po.SetSkipPlotNPTH_Pads(is_cu)
 
             plot_format = self._get_layer_plot_format(output)
 
             # Plot single layer to file
             logging.debug("Opening plot file for layer {} ({})"
-                          .format(layer.layer, suffix))
+                          .format(layer, suffix))
             plot_ctrl.OpenPlotfile(suffix, plot_format, desc)
 
             logging.debug("Plotting layer {} to {}".format(
-                layer.layer, plot_ctrl.GetPlotFileName()))
+                layer, plot_ctrl.GetPlotFileName()))
             plot_ctrl.PlotLayer()
 
     def _configure_excellon_drill_writer(self, board, offset, options):


### PR DESCRIPTION
The current kiplot code checks for layer names.
But it is hardcoded, and in Kicad, we can change inner layer names to whatever we want.

This patch relies on pcbnew API to check if the layer is correct or not.